### PR TITLE
Fix for reserved keyword "default" in IE8.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var through = require('through');
 var filenamePattern = /\.(html|handlebars|hbs)$/;
 
 var wrap = function (template) {
-  return 'var templater = require("handlebars/runtime").default.template;' +
+  return 'var templater = require("handlebars/runtime")["default"].template;' +
          'module.exports = templater(' + template + ');'
 }
 


### PR DESCRIPTION
Fixes the same issue found here: https://github.com/wycats/handlebars.js/pull/696
