### PR TITLE
Fixes headings for better rendering on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-#browserify-handlebars
+# browserify-handlebars
 
 A browserify transform for handlebar templates! Yay!
 
-###Installation:
+### Installation:
 
 `npm install browserify-handlebars`
 
-###Usage:
+### Usage:
 
 Make a handlebars template like so:
 


### PR DESCRIPTION
Some of the headings in the README file are missing spaces after the hashes, so they don't get the proper rendering on npm.
